### PR TITLE
Add missing close parenthesis to logging config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Debugging
 Ideally debugging should be done through "buildozer android logcat", but if you can't do it for some reason, I advise configuring kivy to output to a file on your phone memory, this can be achieved by setting the Config before any other kivy import in your main.py
 
     from kivy.config import Config
-    Config.set('kivy', 'log_dir', '/mnt/sdcard/kivy_logs'
+    Config.set('kivy', 'log_dir', '/mnt/sdcard/kivy_logs')
 
 So you can open them from your file browser with your phone plugged to your computer.
 


### PR DESCRIPTION
This caused me much anguish until I finally noticed the missing close bracket. I should have read it more closely rather than just copying and pasting...

Thanks for the docker image - this is the only way I've managed to package Kivy for Android so far.